### PR TITLE
Handle Number and Symbols emojis

### DIFF
--- a/test/remove_emoji_test.exs
+++ b/test/remove_emoji_test.exs
@@ -116,6 +116,17 @@ defmodule RemoveEmojiTest do
     assert sanitized_string == expect_string
   end
 
+  test "should handle number emojis" do
+    original_string = """
+...
+0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟 #️⃣ *️⃣ ©️ ®️
+...
+"""
+    expect_string = "......"
+    sanitized_string = original_string |> sanitize |> String.replace(~r/\s+/, " ") |> String.trim
+
+    assert sanitized_string == expect_string
+  end
 
   test "should keep normal text" do
     original_string = """


### PR DESCRIPTION
The following do not get replaced correctly:
<img width="465" alt="Screenshot 2020-03-30 at 19 29 46" src="https://user-images.githubusercontent.com/7100966/77948159-dcad8980-72bc-11ea-8312-8963938c4afb.png">

These emojis don't seem to be handled correctly:

https://emojipedia.org/keycap-digit-zero/
https://emojipedia.org/keycap-digit-one/
https://emojipedia.org/keycap-digit-two/
https://emojipedia.org/keycap-digit-three/
https://emojipedia.org/keycap-digit-four/
https://emojipedia.org/keycap-digit-five/
https://emojipedia.org/keycap-digit-six/
https://emojipedia.org/keycap-digit-seven/
https://emojipedia.org/keycap-digit-eight/
https://emojipedia.org/keycap-digit-nine/
https://emojipedia.org/keycap-10/
https://emojipedia.org/keycap-asterisk/
https://emojipedia.org/keycap-number-sign/